### PR TITLE
Move BaseFormSet test to within form_collection loop.

### DIFF
--- a/multipleformwizard/views.py
+++ b/multipleformwizard/views.py
@@ -95,13 +95,12 @@ class MultipleFormWizardView(BaseWizardView):
             form_collection = []
             if isinstance(form, dict):
                 form_collection = form.values()
-            elif issubclass(form, formsets.BaseFormSet):
-                # if the element is based on BaseFormSet (FormSet/ModelFormSet)
-                # we need to override the form variable.
-                form = form.form
-                form_collection = [form]
 
             for form in form_collection:
+                if issubclass(form, formsets.BaseFormSet):
+                    # if the element is based on BaseFormSet (FormSet or 
+                    # ModelFormSet) we need to override the form variable.
+                    form = form.form
                 # check if any form contains a FileField, if yes, we need a
                 # file_storage added to the wizardview (by subclassing).
                 for field in six.itervalues(form.base_fields):

--- a/multipleformwizard/views.py
+++ b/multipleformwizard/views.py
@@ -95,8 +95,15 @@ class MultipleFormWizardView(BaseWizardView):
             form_collection = []
             if isinstance(form, dict):
                 form_collection = form.values()
+            elif issubclass(form, formsets.BaseFormSet):
+                # if the element is based on BaseFormSet (FormSet/ModelFormSet)
+                # we need to override the form variable.
+                form = form.form
+                form_collection = [form]
 
             for form in form_collection:
+                # must test for BaseFormSet again in case form_collection
+                # is a dict containing one.
                 if issubclass(form, formsets.BaseFormSet):
                     # if the element is based on BaseFormSet (FormSet or 
                     # ModelFormSet) we need to override the form variable.


### PR DESCRIPTION
Fixes issue #5. Basically, I moved the BaseFormSet test to within the form_collection loop because you may have a dict containing a formset, which would never see the elif test statement in the original code. 

(Note: I have not added any new tests). 